### PR TITLE
Improving usage from Influx/Telegraf

### DIFF
--- a/influxdb/docker-compose.yaml
+++ b/influxdb/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - DOCKER_INFLUXDB_INIT_BUCKET=karaburan
       - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=token
     volumes:
-      - ./influxdb-data/:/var/lib/influxdb2
+      - ../influxdb/influxdb-data/:/var/lib/influxdb2
 
   telegraf:
     image: telegraf:1.31.0
@@ -30,7 +30,7 @@ services:
       - /proc:/rootfs/proc:ro
       - /sys:/rootfs/sys:ro
       - /etc:/rootfs/etc:ro
-      - ./telegraf.conf:/etc/telegraf/telegraf.conf:ro
+      - ../influxdb/telegraf.conf:/etc/telegraf/telegraf.conf:ro
 
 volumes:
   influxdb-data:

--- a/influxdb/telegraf.conf
+++ b/influxdb/telegraf.conf
@@ -25,6 +25,7 @@
   username = ""
   password = ""
   data_format = "json"
+  json_strict = false
   
 [[inputs.cpu]]
   percpu = true

--- a/mosquitto/docker-compose.yaml
+++ b/mosquitto/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - "1883:1883"
       - "9001:9001" # WebSockets port (optional)
     volumes:
-      - ./config/mosquitto.conf:/mosquitto/config/mosquitto.conf
-      - ./data:/mosquitto/data
-      - ./log:/mosquitto/log
+      - ../mosquitto/config/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - ../mosquitto/data:/mosquitto/data
+      - ../mosquitto/log:/mosquitto/log
     restart: unless-stopped

--- a/tempreader/tempreader.py
+++ b/tempreader/tempreader.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import time
+import datetime
 import paho.mqtt.client as mqtt
 
 SENSOR_TYPE = 'temperature'
@@ -13,7 +14,7 @@ def read_temperature(sensor_id):
     try:
         with open(sensor_file, 'r', encoding="UTF-8") as file:
             temperature = file.read().strip()
-            return temperature
+            return float(temperature)
     except FileNotFoundError:
         print(f"Sensor {sensor_id} not found.")
         return None
@@ -43,7 +44,7 @@ def main():
 
     while True:
         # get value
-        timestamp = time.time()
+        timestamp = datetime.datetime.now(datetime.UTC).isoformat()
         value = read_temperature(args.sensor)
 
         # build measurement structure


### PR DESCRIPTION
These changes allow docker compose to successfully use both mosquitto and influx/telegraf.
Run `docker-compose -f docker-compose.yaml -f ../mosquitto/docker-compose.yaml up -d` from the influxdb folder.

The changes in the script allow for usage of the posted data inside of influxdb. Without it telegraf can't parse the time and influx doesn't know there is floating point data...